### PR TITLE
Use NZBNA_FILENAME in NZBGet Queue Script

### DIFF
--- a/misc/downloaderScripts/hydraNzbgetScript.py
+++ b/misc/downloaderScripts/hydraNzbgetScript.py
@@ -48,7 +48,7 @@ try:
     }
     if queue_event_type is not None:
         hydra_status = nzbget_hydra_status_map[queue_event_type]
-        nzb_name = os.environ.get('NZBPP_NZBFILENAME')
+        nzb_name = os.environ.get('NZBNA_FILENAME')
     else:
         hydra_status = nzbget_hydra_status_map[pp_status]
         nzb_name = os.environ.get('NZBPP_NZBFILENAME')


### PR DESCRIPTION
For queue scripts, the environment variable that contains the NZB name
is called `NZBNA_FILENAME`.