### PR TITLE
Fix incorrect IdType used when converting TMDB ID

### DIFF
--- a/core/src/main/java/org/nzbhydra/DevEndpoint.java
+++ b/core/src/main/java/org/nzbhydra/DevEndpoint.java
@@ -42,7 +42,7 @@ public class DevEndpoint {
         if (imdb != null) {
             return infoProvider.convert(imdb, InfoProvider.IdType.IMDB).toString();
         } else if (tmdb != null) {
-            return infoProvider.convert(tmdb, InfoProvider.IdType.TVDB).toString();
+            return infoProvider.convert(tmdb, InfoProvider.IdType.TMDB).toString();
         } else {
             return "neither tmdb nor imdb set";
         }


### PR DESCRIPTION
The `InfoProvider.IdType` type declaration was mistakenly set to `TVDB` when it should be `TMDB`.  Fixes #171