### PR TITLE
Move Python version check to the beginning of the script

### DIFF
--- a/other/wrapper/nzbhydra2wrapper.py
+++ b/other/wrapper/nzbhydra2wrapper.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python
+
 from __future__ import print_function
+import sys
+
+CURRENT_PYTHON = sys.version_info[:2]
+REQUIRED_PYTHON = (2, 7)
+
+# This check and everything above must remain compatible with Python 2.7 and above.
+if CURRENT_PYTHON > REQUIRED_PYTHON:
+    sys.stderr.write("This script requires Python {}.{}, but you're trying to run it on Python {}.{}.".format(*(REQUIRED_PYTHON + CURRENT_PYTHON)))
+    sys.exit(1)
 
 import argparse
 import logging
@@ -8,7 +18,6 @@ import os
 import platform
 import shutil
 import subprocess
-import sys
 import zipfile
 from __builtin__ import file
 from logging.handlers import RotatingFileHandler
@@ -28,11 +37,6 @@ console_logger.setLevel(LOGGER_DEFAULT_LEVEL)
 logger.addHandler(console_logger)
 file_logger = None
 logger.setLevel(LOGGER_DEFAULT_LEVEL)
-
-if sys.version_info >= (3, 0):
-    sys.stderr.write("Sorry, requires Python 2.7")
-    sys.exit(1)
-
 
 def getBasePath():
     global basepath


### PR DESCRIPTION
Python 3 renamed the `__builtin__` module to `builtins`, so the script would fail due to an ImportError before it ever reached the version check.

I'm not the most experienced at Python, so hopefully the formatting and style is okay!