### PR TITLE
NZBindex was not working

### DIFF
--- a/core/src/main/java/org/nzbhydra/indexers/NzbIndex.java
+++ b/core/src/main/java/org/nzbhydra/indexers/NzbIndex.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 public class NzbIndex extends Indexer<NewznabXmlRoot> {
 
     private static final Logger logger = LoggerFactory.getLogger(NzbIndex.class);
-    private static final Pattern GUID_PATTERN = Pattern.compile(".*/release/(\\d+).*", Pattern.DOTALL);
+    private static final Pattern GUID_PATTERN = Pattern.compile(".*/download/(\\d+).*", Pattern.DOTALL);
     private static final Pattern NFO_PATTERN = Pattern.compile(".*<pre id=\"nfo0\">(.*)</pre>.*", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     @Override
@@ -56,9 +56,11 @@ public class NzbIndex extends Indexer<NewznabXmlRoot> {
             SearchResultItem item = new SearchResultItem();
             item.setPubDate(rssItem.getPubDate());
             String nzbIndexLink = rssItem.getLink();
-            item.setTitle(nzbIndexLink.substring(nzbIndexLink.lastIndexOf('/') + 1, nzbIndexLink.length() - 4)); //Use the NZB name as title because it's already somewhat cleaned up
+            item.setTitle(nzbIndexLink.substring(nzbIndexLink.lastIndexOf("/",nzbIndexLink.length()-2)+1, nzbIndexLink.length() - 1)); //Use the NZB name as title because it's already somewhat cleaned up
             item.setAgePrecise(true);
-            item.setGroup(rssItem.getCategory().replace("a.b", "alt.binaries"));
+            if (rssItem.getCategory()!=null) {
+                item.setGroup(rssItem.getCategory().replace("a.b", "alt.binaries"));
+            }
             item.setLink(rssItem.getEnclosure().getUrl());
             item.setSize(rssItem.getEnclosure().getLength());
             Matcher matcher = GUID_PATTERN.matcher(nzbIndexLink);
@@ -71,7 +73,11 @@ public class NzbIndex extends Indexer<NewznabXmlRoot> {
             item.setCategory(categoryProvider.getNotAvailable());
             item.setOriginalCategory("N/A");
             item.setIndexerScore(config.getScore().orElse(0));
-            item.setHasNfo(rssItem.getDescription().contains("1 NFO") ? HasNfo.YES : HasNfo.NO);
+            if (item.getDescription()!=null) {
+                item.setHasNfo(rssItem.getDescription().contains("1 NFO") ? HasNfo.YES : HasNfo.NO);
+            }else {
+                item.setHasNfo(HasNfo.NO);
+            }
             item.setIndexer(this);
             item.setDownloadType(DownloadType.NZB);
             items.add(item);

--- a/core/src/test/java/org/nzbhydra/indexers/NzbIndexTest.java
+++ b/core/src/test/java/org/nzbhydra/indexers/NzbIndexTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.junit.Assert.assertThat;
 
 
@@ -41,17 +42,14 @@ public class NzbIndexTest {
     @Test
     public void shouldParseRows() throws Exception {
         Instant now = Instant.now();
-        String enclosureUrl = "http://nzbindex.com/download/164950363/Watchers.of.the.Universe.S02E09.1080p.WEB-DL.DD5.1.AAC2.0.H.264-YFN-0030-Watchers.of.the.Universe.S02E09.Cant.Get.You.out.of.My.Head.1080p.WEB-DL.nzb";
-        String link = "http://nzbindex.com/release/164950363/Watchers.of.the.Universe.S02E09.1080p.WEB-DL.DD5.1.AAC2.0.H.264-YFN-0030-Watchers.of.the.Universe.S02E09.Cant.Get.You.out.of.My.Head.1080p.WEB-DL.nzb";
+        String enclosureUrl = "http://nzbindex.com/download/164950363/";
+        String link = "http://nzbindex.com/download/164950363/";
+        String guid = "http://nzbindex.com/collection/164950363/";
         NewznabXmlRoot root = RssBuilder.builder().items(
                 Arrays.asList(
                         RssItemBuilder
                                 .builder("[ Watchers.of.the.Universe.S02E09.1080p.WEB-DL.DD5.1.AAC2.0.H.264-YFN ] - [00/30] - \"Watchers.of.the.Universe.S02E09.Cant.Get.You.out.of.My.Head.1080p.WEB-DL.DD5.1.AAC2.0.H.264-YFN.nzb\" yEnc\n")
                                 .link(link)
-                                .description("<![CDATA[\n" +
-                                        "<p><font color=\"gray\">alt.binaries.hdtv.x264</font><br /> <b>1.01 GB</b><br /> 7 hours<br /> <font color=\"#3DA233\">31 files (1405 parts)</font> <font color=\"gray\">by s@nd.p (SP)</font><br /> <font color=\"#E2A910\"> 1 NFO | 9 PAR2 | 1 NZB | 19 ARCHIVE</font> - <a href=\"http://nzbindex.com/nfo/164950363/Watchers.of.the.Universe.S02E09.1080p.WEB-DL.DD5.1.AAC2.0.H.264-YFN-0030-Watchers.of.the.Universe.S02E09.Cant.Get.You.out.of.My.Head.1080p.WEB-DL.nzb/?q=\" target=\"_blank\">View NFO</a></p>\n" +
-                                        "]]>")
-                                .category("alt.binaries.hdtv.x264")
                                 .pubDate(now)
                                 .rssGuid(new NewznabXmlGuid(link, true))
                                 .enclosure(new NewznabXmlEnclosure(enclosureUrl, 1089197181L, "application/x-nzb"))
@@ -60,14 +58,13 @@ public class NzbIndexTest {
         assertThat(items.size(), is(1));
         SearchResultItem item = items.get(0);
 
-        assertThat(item.getTitle(), is("Watchers.of.the.Universe.S02E09.1080p.WEB-DL.DD5.1.AAC2.0.H.264-YFN-0030-Watchers.of.the.Universe.S02E09.Cant.Get.You.out.of.My.Head.1080p.WEB-DL"));
-        assertThat(item.getGroup().get(), is("alt.binaries.hdtv.x264"));
+        assertThat(item.getTitle(), is("164950363"));
         assertThat(item.getPubDate(), is(now));
         assertThat(item.isAgePrecise(), is(true));
         assertThat(item.getSize(), is(1089197181L));
         assertThat(item.getIndexerGuid(), is("164950363"));
         assertThat(item.getDownloadType(), is(DownloadType.NZB));
-        assertThat(item.getHasNfo(), is(HasNfo.YES));
+        assertThat(item.getHasNfo(), is(HasNfo.NO));
 
     }
 


### PR DESCRIPTION
RSS feed of nzbindex seems to have change.

I modify the code to reflect this:

<rss version="2.0">
<channel>
<title>NZBIndex</title>
<description>The NZBIndex RSS feed</description>
<link>https://nzbindex.com/</link>
<item>
<title>
the title
</title>
<link>https://nzbindex.com/download/15762767/</link>
<guid>https://nzbindex.com/collection/15762607</guid>
<enclosure url="https://nzbindex.com/download/15762607/" length="17761130" type="application/x-nzb"/>
<author>ydssd</author>
<pubDate>Sat, 19 Jan 2019 08:37:57 +0000</pubDate>
<size>685761130</size>
<groups>
<groups>alt.binaries.town</groups>
</groups>
<total_parts>1795</total_parts>
<available_parts>1795</available_parts>
<complete>1</complete>
<files>4</files>
</item>
<item>