### PR TITLE
Fixed detection of OpenJDK 9 on Raspbian

### DIFF
--- a/other/wrapper/nzbhydra2wrapper.py
+++ b/other/wrapper/nzbhydra2wrapper.py
@@ -491,7 +491,7 @@ def getJavaVersion(javaExecutable):
         if len(lines) == 0:
             raise Exception("Unable to get output from call to java -version")
         versionLine = lines[0].replace("\n", "").replace("\r", "")
-        match = re.match('(java|openjdk) version "(?P<major>\d+)(\.(?P<minor>\d+)\.(?P<patch>\d)+[\-_\w]*)?".*', versionLine)
+        match = re.match('(java|openjdk) version "(?P<major>\d+)((\.(?P<minor>\d+)\.(?P<patch>\d)+)?[\-_\w]*)?".*', versionLine)
         if match is None:
             raise Exception("Unable to determine java version from string " + lines[0])
         javaMajor = int(match.group("major"))


### PR DESCRIPTION
The version string of openjdk9 on raspbian stretch is 'openjdk version "9-Raspbian"', which is not recognized by the regex. I modified the regex to treat the minor and patch parts of the version string as optional