### PR TITLE
Add 3 User Agents to Config

### DIFF
--- a/core/src/main/resources/config/baseConfig.yml
+++ b/core/src/main/resources/config/baseConfig.yml
@@ -365,6 +365,6 @@ searching:
   timeout: 20
   transformNewznabCategories: true
   userAgent: "NZBHydra2"
-  userAgents: [ "Mozilla", "Sonarr", "Radarr", "CouchPotato", "LazyLibrarian", "Lidarr", "NZBGet", "sabNZBd" ]
+  userAgents: [ "Mozilla", "Sonarr", "Radarr", "CouchPotato", "LazyLibrarian", "Lidarr", "Mylar", "Readarr", "NZB360", "NZBGet", "sabNZBd" ]
   useOriginalCategories: false
   wrapApiErrors: false


### PR DESCRIPTION
Hi

I recently noticed that my Other was massive in the stats and wanted to work out what was causing it - so I added 3 User Agents manually.

This PR is to add as a default options these 3 user agents for

NZB360
Mylar
Readarr (Currently pre Alpha so future proof)

Thanks