### PR TITLE
wrapper: Fix dropping every second line of stdout

### DIFF
--- a/other/wrapper/nzbhydra2wrapperPy3.py
+++ b/other/wrapper/nzbhydra2wrapperPy3.py
@@ -424,7 +424,7 @@ def startup():
         while True:
             # Handle error first in case startup of main process returned only an error (on stderror)
             nextline = process.stdout.readline()
-            nextlineString = process.stdout.readline().decode("utf-8")
+            nextlineString = nextline.decode("utf-8")
             if nextlineString == '' and process.poll() is not None:
                 break
             if nextlineString != "":


### PR DESCRIPTION
Since `readline()` was called twice on `stdout`, every second line of nzbhydra's output was previously dropped.