### PR TITLE
tasks: allow environment to disable tasks

### DIFF
--- a/core/ui-src/html/directives/tasks.html
+++ b/core/ui-src/html/directives/tasks.html
@@ -30,7 +30,7 @@
                 <td class="col-md-5" style="text-align: left"><span ng-show="task.lastExecutionTime"
                                                                     uib-tooltip="{{task.lastExecutionTime | reformatDateSeconds}}">{{ task.lastExecutionTime | humanizeDate }}</span>
                 </td>
-                <td class="col-md-5" style="text-align: left"><span
+                <td class="col-md-5" style="text-align: left"><span ng-show="task.nextExecutionTime"
                         uib-tooltip="{{task.nextExecutionTime | reformatDateSeconds}}">{{task.nextExecutionTime | humanizeDate}}</span>
                 </td>
             </tr>


### PR DESCRIPTION
This PR allows the user to disable certain hydra tasks, by setting the respective interval environment variable to 0. E.g. `hydraTasks.installUpdate=0` would disable the "Check for and install updates" task. Disabled tasks can still be run manually via the web interface.