### PR TITLE
Update baseConfig.yml to include UHD results

### DIFF
--- a/core/src/main/resources/config/baseConfig.yml
+++ b/core/src/main/resources/config/baseConfig.yml
@@ -147,6 +147,7 @@ categoriesConfig:
       applySizeLimitsToApi: false
       newznabCategories:
         - "2040"
+        - "2045"
         - "2050"
         - "2060"
         - "2070"
@@ -224,6 +225,7 @@ categoriesConfig:
       applySizeLimitsToApi: false
       newznabCategories:
         - "5040"
+        - "5045"
       requiredRegex: null
       requiredWords: []
       preselect: true

--- a/core/src/main/resources/config/baseConfig.yml
+++ b/core/src/main/resources/config/baseConfig.yml
@@ -142,7 +142,7 @@ categoriesConfig:
       forbiddenRegex: null
       forbiddenWords: []
       ignoreResultsFrom: NONE
-      maxSizePreset: 20000
+      maxSizePreset: 90000
       minSizePreset: 3000
       applySizeLimitsToApi: false
       newznabCategories:
@@ -220,7 +220,7 @@ categoriesConfig:
       forbiddenRegex: null
       forbiddenWords: []
       ignoreResultsFrom: NONE
-      maxSizePreset: 4500
+      maxSizePreset: 12000
       minSizePreset: 300
       applySizeLimitsToApi: false
       newznabCategories:


### PR DESCRIPTION
UHD is a subset of HD, so it arguably makes sense to include 4k results when searching for HD (instead of creating a new category).

I realise that `maxSizePreset` will also need to be increased if we don't make a new category. @theotherp What do you think is best?