### PR TITLE
wrapper: use raw string literals for regular expressions

### DIFF
--- a/other/wrapper/nzbhydra2wrapper.py
+++ b/other/wrapper/nzbhydra2wrapper.py
@@ -548,7 +548,7 @@ def getJavaVersion(javaExecutable):
         if len(lines) == 0:
             raise Exception("Unable to get output from call to java -version")
         versionLine = lines[0].replace("\n", "").replace("\r", "")
-        match = re.match('(java|openjdk) (version )?"?(?P<major>\d+)((\.(?P<minor>\d+)\.(?P<patch>\d)+)?[\-_\w]*)?"?.*',
+        match = re.match(r'(java|openjdk) (version )?"?(?P<major>\d+)((\.(?P<minor>\d+)\.(?P<patch>\d)+)?[\-_\w]*)?"?.*',
                          versionLine)
         if match is None:
             raise Exception("Unable to determine java version from string " + lines[0])

--- a/other/wrapper/nzbhydra2wrapperPy3.py
+++ b/other/wrapper/nzbhydra2wrapperPy3.py
@@ -581,7 +581,7 @@ def getJavaVersion(javaExecutable):
         if len(lines) == 0:
             raise Exception("Unable to get output from call to java -version")
         versionLine = lines[0].replace("\n", "").replace("\r", "")
-        match = re.match('(java|openjdk) (version )?"?(?P<major>\d+)((\.(?P<minor>\d+)\.(?P<patch>\d)+)?[\-_\w]*)?"?.*', versionLine)
+        match = re.match(r'(java|openjdk) (version )?"?(?P<major>\d+)((\.(?P<minor>\d+)\.(?P<patch>\d)+)?[\-_\w]*)?"?.*', versionLine)
         if match is None:
             raise Exception("Unable to determine java version from string " + lines[0])
         javaMajor = int(match.group("major"))


### PR DESCRIPTION
This fixes a SyntaxWarning with Python 3.12:

```
/usr/lib/nzbhydra2/nzbhydra2wrapperPy3.py:584: SyntaxWarning: invalid escape sequence '\d'
  match = re.match('(java|openjdk) (version )?"?(?P<major>\d+)((\.(?P<minor>\d+)\.(?P<patch>\d)+)?[\-_\w]*)?"?.*', versionLine)
```

Although Python 2 doesn't print a warning, using a raw string literal is the correct thing to do, so I applied this change to the Python 2 wrapper as well.