### PR TITLE
fix: update nzbhydra2 to work with Java >17.0.9

### DIFF
--- a/other/wrapper/nzbhydra2wrapperPy3.py
+++ b/other/wrapper/nzbhydra2wrapperPy3.py
@@ -581,7 +581,7 @@ def getJavaVersion(javaExecutable):
         if len(lines) == 0:
             raise Exception("Unable to get output from call to java -version")
         versionLine = lines[0].replace("\n", "").replace("\r", "")
-        match = re.match('(java|openjdk) (version )?"?(?P<major>\d+)((\.(?P<minor>\d+)\.(?P<patch>\d)+)?[\-_\w]*)?"?.*', versionLine)
+        match = re.match('(java|openjdk) (version )?"?(?P<major>\d+)((\.(?P<minor>\d+)\.(?P<patch>\d+))?[\-_\w]*)?"?.*', versionLine)
         if match is None:
             raise Exception("Unable to determine java version from string " + lines[0])
         javaMajor = int(match.group("major"))


### PR DESCRIPTION
Hope you get better, here's a small fix for those running Java >17.0.9 since 17.0.14 is the latest Java version.