### PR TITLE
fix: close FileReader in loadPackageInfoFile to prevent resource leak

### DIFF
--- a/core/src/main/java/org/nzbhydra/update/UpdateManager.java
+++ b/core/src/main/java/org/nzbhydra/update/UpdateManager.java
@@ -115,8 +115,8 @@ public class UpdateManager implements InitializingBean {
 
     private void loadPackageInfoFile(File lsioPackageFile) {
         Properties properties = new Properties();
-        try {
-            properties.load(new FileReader(lsioPackageFile));
+        try (FileReader reader = new FileReader(lsioPackageFile)) {
+            properties.load(reader);
             packageInfo = new PackageInfo(properties.getProperty("ReleaseType"), properties.getProperty("PackageVersion"), properties.getProperty("PackageAuthor"));
         } catch (IOException e) {
             logger.error("Unable to read package info", e);


### PR DESCRIPTION
## Summary

Fixes #1042

This PR addresses a resource leak in the `UpdateManager.loadPackageInfoFile` method where a FileReader is created but never closed, potentially causing file descriptor exhaustion.

## Location

`core/src/main/java/org/nzbhydra/update/UpdateManager.java:119`

## Impact

**Before this fix:**
- FileReader created but never closed
- File descriptors leak on every call to loadPackageInfoFile
- Can lead to file descriptor exhaustion on systems with limited handles
- May prevent proper file deletion on Windows where open handles block deletion

**After this fix:**
- FileReader properly closed via try-with-resources
- No resource leaks
- Follows Java best practices for resource management

## Changes

- Wrapped FileReader creation in try-with-resources statement
- Ensured automatic cleanup regardless of success or exception

## Testing

- Code review confirms proper resource cleanup
- Try-with-resources is the standard Java pattern for automatic resource management
- No functional behavior changes, only resource cleanup improvement
