### PR TITLE
fix: close FileReader in debug info generation to prevent resource leak

### DIFF
--- a/core/src/main/java/org/nzbhydra/debuginfos/DebugInfosProvider.java
+++ b/core/src/main/java/org/nzbhydra/debuginfos/DebugInfosProvider.java
@@ -286,7 +286,9 @@ public class DebugInfosProvider {
 
                 File servLogFile = new File(logsFolder, "nzbhydra2.serv.log");
                 if (servLogFile.exists()) {
-                    writeStringToZip(zos, "nzbhydra2.serv.log", logAnonymizer.getAnonymizedLog(IOUtils.toString(new FileReader(servLogFile))).getBytes());
+                    try (FileReader reader = new FileReader(servLogFile)) {
+                        writeStringToZip(zos, "nzbhydra2.serv.log", logAnonymizer.getAnonymizedLog(IOUtils.toString(reader)).getBytes());
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes #1044

This PR addresses a resource leak in the `DebugInfosProvider.createDebugInfosZip` method where a FileReader is created inline and never closed, potentially causing file descriptor exhaustion.

## Location

`core/src/main/java/org/nzbhydra/debuginfos/DebugInfosProvider.java:289`

## Impact

**Before this fix:**
- FileReader created inline and passed to IOUtils.toString() without being closed
- File descriptor leaked every time debug info is generated with server logs
- Can lead to file descriptor exhaustion on systems with limited handles
- May prevent proper file deletion on Windows where open handles block deletion

**After this fix:**
- FileReader properly closed via try-with-resources
- No resource leaks during debug info generation
- Follows Java best practices for resource management

## Changes

- Wrapped FileReader creation in try-with-resources statement
- Ensured automatic cleanup regardless of success or exception
- No functional behavior changes, only resource cleanup improvement

## Testing

- Code review confirms proper resource cleanup
- Try-with-resources is the standard Java pattern for automatic resource management
- Debug info generation will continue to work identically but without leaking file handles
