### PR TITLE
fix: close FileReader instances to prevent resource leaks

### DIFF
--- a/core/src/main/java/org/nzbhydra/debuginfos/DebugInfosProvider.java
+++ b/core/src/main/java/org/nzbhydra/debuginfos/DebugInfosProvider.java
@@ -286,7 +286,9 @@ public class DebugInfosProvider {
 
                 File servLogFile = new File(logsFolder, "nzbhydra2.serv.log");
                 if (servLogFile.exists()) {
-                    writeStringToZip(zos, "nzbhydra2.serv.log", logAnonymizer.getAnonymizedLog(IOUtils.toString(new FileReader(servLogFile))).getBytes());
+                    try (FileReader reader = new FileReader(servLogFile)) {
+                        writeStringToZip(zos, "nzbhydra2.serv.log", logAnonymizer.getAnonymizedLog(IOUtils.toString(reader)).getBytes());
+                    }
                 }
             }
         }

--- a/core/src/main/java/org/nzbhydra/update/UpdateManager.java
+++ b/core/src/main/java/org/nzbhydra/update/UpdateManager.java
@@ -115,8 +115,8 @@ public class UpdateManager implements InitializingBean {
 
     private void loadPackageInfoFile(File lsioPackageFile) {
         Properties properties = new Properties();
-        try {
-            properties.load(new FileReader(lsioPackageFile));
+        try (FileReader reader = new FileReader(lsioPackageFile)) {
+            properties.load(reader);
             packageInfo = new PackageInfo(properties.getProperty("ReleaseType"), properties.getProperty("PackageVersion"), properties.getProperty("PackageAuthor"));
         } catch (IOException e) {
             logger.error("Unable to read package info", e);


### PR DESCRIPTION
## Summary
- Fixes two resource leaks where FileReader instances were created but never closed
- Uses try-with-resources pattern for automatic cleanup
- Prevents file descriptor exhaustion and memory leaks

## Problems Fixed

### Issue #1044 - DebugInfosProvider.java:289
When creating debug info ZIP files, a FileReader was created inline to read the server log file but never closed:
```java
writeStringToZip(zos, "nzbhydra2.serv.log", logAnonymizer.getAnonymizedLog(IOUtils.toString(new FileReader(servLogFile))).getBytes());
```

### Issue #1042 - UpdateManager.java:119
During application startup, a FileReader was created to load package info but never closed:
```java
properties.load(new FileReader(lsioPackageFile));
```

## Impact
Both leaks could cause:
- File descriptor exhaustion on systems with limited file handles
- Memory leaks as unclosed streams consume resources  
- File deletion issues on Windows where open file handles block deletion
- Issues occurring during routine operations (startup, debug info generation)

## Solution
Refactored both methods to use try-with-resources:
```java
try (FileReader reader = new FileReader(file)) {
    // use reader
}
```

This ensures the FileReader is automatically closed even if exceptions occur.

## Testing
- Verified code compiles cleanly
- Pattern follows Java best practices for resource management
- Changes are minimal and focused on resource cleanup only

Fixes #1044
Fixes #1042