### PR TITLE
Fix 'Load More' pagination bug

### DIFF
--- a/core/ui-src/js/search-service.js
+++ b/core/ui-src/js/search-service.js
@@ -66,7 +66,12 @@ function SearchService($http) {
     }
 
     function loadMore(offset, limit, loadAll) {
-        return $http.post(lastExecutedQuery.toString(), lastExecutedSearchRequestParameters).then(processData);
+        var params = angular.extend({}, lastExecutedSearchRequestParameters);
+        params.offset = offset;
+        params.limit = limit;
+        params.loadAll = angular.isDefined(loadAll) ? loadAll : false;
+
+        return $http.post(lastExecutedQuery.toString(), params).then(processData);
     }
 
     function shortcutSearch(searchRequestId) {


### PR DESCRIPTION
In commit 021ded9, the assignments to lastExecutedSearchRequestParameters inside loadMore() were removed to prevent pagination parameters from leaking into saved searches. However, this inadvertently caused loadMore() to send requests without offset, limit, and loadAll parameters, which broke pagination entirely (it simply re-requested the first page).

This PR fixes the issue by cloning the global parameters object and appending the pagination parameters to the clone before sending the request. This restores pagination functionality while keeping the global object clean for saved searches.