### PR TITLE
Add Hydracker Newznab preset

### DIFF
--- a/core/ui-src/js/config/formly-indexers.js
+++ b/core/ui-src/js/config/formly-indexers.js
@@ -606,6 +606,11 @@ angular.module('nzbhydraApp').controller('IndexerConfigSelectionBoxInstanceContr
             host: "https://fastnzb.com"
         },
         {
+            name: "Hydracker",
+            host: "https://hydracker.com",
+            apiPath: "/api/v1/newznab"
+        },
+        {
             name: "LuluNZB",
             host: "https://lulunzb.com"
         },


### PR DESCRIPTION
## Summary

- add Hydracker to the built-in Newznab preset list
- prefill `https://hydracker.com` as the host
- prefill `/api/v1/newznab` as the API path

## Why

Hydracker exposes a Newznab-compatible API for movies, series, anime, music, books, games, applications, and other NZB content. Adding a preset lets users configure it without manually entering the endpoint.

## Validation

- `node --check core/ui-src/js/config/formly-indexers.js`
- `git diff --check`
- verified that the configured endpoint responds with Newznab XML and the expected authentication error when no API key is supplied
