### PR TITLE
fix redirect exception for treasure-maps after domain change

### DIFF
--- a/core/src/main/java/org/nzbhydra/downloading/IndexerSpecificDownloadExceptions.java
+++ b/core/src/main/java/org/nzbhydra/downloading/IndexerSpecificDownloadExceptions.java
@@ -51,7 +51,7 @@ public class IndexerSpecificDownloadExceptions {
                || host.contains("abnzb")
                || host.contains("digitalcarnage")
                || host.contains("tabula-rasa")
-               || host.contains("scenenzb")
+               || host.contains("treasure-maps")
                 ;
     }
 


### PR DESCRIPTION
small fix for treasure-maps download type override after domain change in https://github.com/theotherp/nzbhydra2/commit/df26da694ff275538d1a8ff39d7e088788d94c64